### PR TITLE
feat: add a function to parse jsonb only

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -62,6 +62,11 @@ pub fn from_slice(buf: &[u8]) -> Result<Value<'_>, Error> {
     }
 }
 
+pub fn parse_jsonb(buf: &[u8]) -> Result<Value<'_>, Error> {
+    let mut decoder = Decoder::new(buf);
+    decoder.decode()
+}
+
 #[repr(transparent)]
 pub struct Decoder<'a> {
     buf: &'a [u8],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ mod ser;
 mod util;
 mod value;
 
-pub use de::from_slice;
+pub use de::{from_slice, parse_jsonb};
 pub use error::Error;
 #[allow(unused_imports)]
 pub use from::*;


### PR DESCRIPTION
Currently we use `from_slice` to parse jsonb to `Value`, but cannot distinguish jsonb and json strings for compatibility. This patch add a function for parsing jsonb only similar to `parse_value`.