### PR TITLE
Refactor: get object value by key name improve performance

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -21,7 +21,6 @@ use crate::core::Deserializer;
 use crate::core::JsonbItemType;
 use crate::core::ObjectIterator;
 use crate::error::*;
-use crate::Number;
 use crate::OwnedJsonb;
 
 /// Represents JSONB data wrapped around a raw, immutable slice of bytes.
@@ -270,26 +269,26 @@ impl PartialOrd for RawJsonb<'_> {
                 Some(self_len.cmp(&other_len))
             }
             (JsonbItemType::String, JsonbItemType::String) => {
-                let self_val: Result<String> = from_raw_jsonb(self);
-                let other_val: Result<String> = from_raw_jsonb(other);
+                let self_val = self.as_str();
+                let other_val = other.as_str();
                 match (self_val, other_val) {
-                    (Ok(self_val), Ok(other_val)) => self_val.partial_cmp(&other_val),
+                    (Ok(Some(self_val)), Ok(Some(other_val))) => self_val.partial_cmp(&other_val),
                     (_, _) => None,
                 }
             }
             (JsonbItemType::Number, JsonbItemType::Number) => {
-                let self_val: Result<Number> = from_raw_jsonb(self);
-                let other_val: Result<Number> = from_raw_jsonb(other);
+                let self_val = self.as_number();
+                let other_val = other.as_number();
                 match (self_val, other_val) {
-                    (Ok(self_val), Ok(other_val)) => self_val.partial_cmp(&other_val),
+                    (Ok(Some(self_val)), Ok(Some(other_val))) => self_val.partial_cmp(&other_val),
                     (_, _) => None,
                 }
             }
             (JsonbItemType::Boolean, JsonbItemType::Boolean) => {
-                let self_val: Result<bool> = from_raw_jsonb(self);
-                let other_val: Result<bool> = from_raw_jsonb(other);
+                let self_val = self.as_bool();
+                let other_val = other.as_bool();
                 match (self_val, other_val) {
-                    (Ok(self_val), Ok(other_val)) => self_val.partial_cmp(&other_val),
+                    (Ok(Some(self_val)), Ok(Some(other_val))) => self_val.partial_cmp(&other_val),
                     (_, _) => None,
                 }
             }


### PR DESCRIPTION
1. Refactor the implementation of get object value by the key name, avoid reading all the key jentries at one time, change to a lazy mode, only read when need, avoid the performance impact of reading a lot of keys.
2. Check whether the length of the object's key is equal to the needed key name first, to reduce the call of `equal` function.
3. Avoid using `Deserializer` to convert the type of data inside the function, because usually we already know the type, we can extract it directly to avoid extra judgement in the conversion process of `Deserializer`.
