### PR TITLE
Feat: support extension types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,10 @@ rust-version = "1.80"
 
 [dependencies]
 byteorder = "1.5.0"
+ethnum = "1.5.1"
 fast-float2 = "0.2.3"
 itoa = "1.0"
+jiff = "0.2.10"
 nom = "8.0.0"
 num-traits = "0.2.19"
 ordered-float = { version = "5.0", default-features = false }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -29,11 +29,11 @@ pub(crate) const TT: char = '\x09'; // \t Horizontal Tab
 pub(crate) const NULL_LEVEL: u8 = 8;
 pub(crate) const ARRAY_LEVEL: u8 = 7;
 pub(crate) const OBJECT_LEVEL: u8 = 6;
-pub(crate) const EXTENSION_LEVEL: u8 = 5;
-pub(crate) const STRING_LEVEL: u8 = 4;
-pub(crate) const NUMBER_LEVEL: u8 = 3;
-pub(crate) const TRUE_LEVEL: u8 = 2;
-pub(crate) const FALSE_LEVEL: u8 = 1;
+pub(crate) const STRING_LEVEL: u8 = 5;
+pub(crate) const NUMBER_LEVEL: u8 = 4;
+pub(crate) const TRUE_LEVEL: u8 = 3;
+pub(crate) const FALSE_LEVEL: u8 = 2;
+pub(crate) const EXTENSION_LEVEL: u8 = 1;
 
 pub(crate) const TYPE_STRING: &str = "string";
 pub(crate) const TYPE_NULL: &str = "null";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -26,9 +26,10 @@ pub(crate) const RR: char = '\x0D'; // \r Carriage Return
 pub(crate) const TT: char = '\x09'; // \t Horizontal Tab
 
 // JSONB value compare level
-pub(crate) const NULL_LEVEL: u8 = 7;
-pub(crate) const ARRAY_LEVEL: u8 = 6;
-pub(crate) const OBJECT_LEVEL: u8 = 5;
+pub(crate) const NULL_LEVEL: u8 = 8;
+pub(crate) const ARRAY_LEVEL: u8 = 7;
+pub(crate) const OBJECT_LEVEL: u8 = 6;
+pub(crate) const EXTENSION_LEVEL: u8 = 5;
 pub(crate) const STRING_LEVEL: u8 = 4;
 pub(crate) const NUMBER_LEVEL: u8 = 3;
 pub(crate) const TRUE_LEVEL: u8 = 2;
@@ -40,3 +41,9 @@ pub(crate) const TYPE_BOOLEAN: &str = "boolean";
 pub(crate) const TYPE_NUMBER: &str = "number";
 pub(crate) const TYPE_ARRAY: &str = "array";
 pub(crate) const TYPE_OBJECT: &str = "object";
+pub(crate) const TYPE_DECIMAL: &str = "decimal";
+pub(crate) const TYPE_BINARY: &str = "binary";
+pub(crate) const TYPE_DATE: &str = "date";
+pub(crate) const TYPE_TIMESTAMP: &str = "timestamp";
+pub(crate) const TYPE_TIMESTAMP_TZ: &str = "timestamp_tz";
+pub(crate) const TYPE_INTERVAL: &str = "interval";

--- a/src/core/databend/builder.rs
+++ b/src/core/databend/builder.rs
@@ -199,6 +199,11 @@ fn append_jsonb_item(buf: &mut Vec<u8>, jentry_index: &mut usize, item: JsonbIte
             replace_jentry(buf, jentry, jentry_index);
             buf.extend_from_slice(data);
         }
+        JsonbItem::Extension(data) => {
+            let jentry = JEntry::make_extension_jentry(data.len());
+            replace_jentry(buf, jentry, jentry_index);
+            buf.extend_from_slice(data);
+        }
         JsonbItem::Raw(raw_jsonb) => {
             append_raw_jsonb_data(buf, jentry_index, raw_jsonb)?;
         }

--- a/src/core/databend/constants.rs
+++ b/src/core/databend/constants.rs
@@ -27,6 +27,7 @@ pub(super) const NUMBER_TAG: u32 = 0x20000000;
 pub(super) const FALSE_TAG: u32 = 0x30000000;
 pub(super) const TRUE_TAG: u32 = 0x40000000;
 pub(super) const CONTAINER_TAG: u32 = 0x50000000;
+pub(super) const EXTENSION_TAG: u32 = 0x60000000;
 
 // JSONB number constants
 pub(super) const NUMBER_ZERO: u8 = 0x00;
@@ -36,6 +37,14 @@ pub(super) const NUMBER_NEG_INF: u8 = 0x30;
 pub(super) const NUMBER_INT: u8 = 0x40;
 pub(super) const NUMBER_UINT: u8 = 0x50;
 pub(super) const NUMBER_FLOAT: u8 = 0x60;
+pub(super) const NUMBER_DECIMAL: u8 = 0x70;
+
+// JSONB extension constants
+pub(super) const EXTENSION_BINARY: u8 = 0x00;
+pub(super) const EXTENSION_DATE: u8 = 0x10;
+pub(super) const EXTENSION_TIMESTAMP: u8 = 0x20;
+pub(super) const EXTENSION_TIMESTAMP_TZ: u8 = 0x30;
+pub(super) const EXTENSION_INTERVAL: u8 = 0x40;
 
 // @todo support offset mode
 #[allow(dead_code)]

--- a/src/core/databend/jentry.rs
+++ b/src/core/databend/jentry.rs
@@ -69,6 +69,13 @@ impl JEntry {
         }
     }
 
+    pub(super) fn make_extension_jentry(length: usize) -> JEntry {
+        JEntry {
+            type_code: EXTENSION_TAG,
+            length: length as u32,
+        }
+    }
+
     pub(super) fn encoded(&self) -> u32 {
         self.type_code | self.length
     }

--- a/src/core/item.rs
+++ b/src/core/item.rs
@@ -31,6 +31,8 @@ pub(crate) enum JsonbItemType {
     Number,
     /// The String JSONB type.
     String,
+    /// The Extension JSONB type.
+    Extension,
     /// The Array JSONB type with the length of items.
     Array(usize),
     /// The Object JSONB type with the length of key and value pairs.
@@ -64,6 +66,10 @@ impl PartialOrd for JsonbItemType {
             (JsonbItemType::String, _) => Some(Ordering::Greater),
             (_, JsonbItemType::String) => Some(Ordering::Less),
 
+            (JsonbItemType::Extension, JsonbItemType::Extension) => None,
+            (JsonbItemType::Extension, _) => Some(Ordering::Greater),
+            (_, JsonbItemType::Extension) => Some(Ordering::Less),
+
             (JsonbItemType::Number, JsonbItemType::Number) => None,
             (JsonbItemType::Number, _) => Some(Ordering::Greater),
             (_, JsonbItemType::Number) => Some(Ordering::Less),
@@ -92,6 +98,8 @@ pub(crate) enum JsonbItem<'a> {
     Number(&'a [u8]),
     /// Represents a JSONB string, stored as a byte slice.
     String(&'a [u8]),
+    /// Represents a JSONB extension values, stored as a byte slice.
+    Extension(&'a [u8]),
     /// Represents raw JSONB data, using a borrowed slice.
     Raw(RawJsonb<'a>),
     /// Represents owned JSONB data.
@@ -105,6 +113,7 @@ impl<'a> JsonbItem<'a> {
             JsonbItem::Boolean(_) => Ok(JsonbItemType::Boolean),
             JsonbItem::Number(_) => Ok(JsonbItemType::Number),
             JsonbItem::String(_) => Ok(JsonbItemType::String),
+            JsonbItem::Extension(_) => Ok(JsonbItemType::Extension),
             JsonbItem::Raw(raw) => raw.jsonb_item_type(),
             JsonbItem::Owned(owned) => owned.as_raw().jsonb_item_type(),
         }

--- a/src/core/item.rs
+++ b/src/core/item.rs
@@ -16,6 +16,7 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 
 use crate::error::*;
+use crate::ExtensionValue;
 use crate::Number;
 use crate::OwnedJsonb;
 use crate::RawJsonb;
@@ -183,12 +184,12 @@ impl PartialOrd for JsonbItem<'_> {
             (JsonbItem::Raw(_), JsonbItem::Null) => Some(Ordering::Less),
             (JsonbItem::Null, JsonbItem::Raw(_)) => Some(Ordering::Greater),
             // compare extension
-            (JsonbItem::Extension(self_val), JsonbItem::Extension(other_val)) => {
+            (JsonbItem::Extension(self_data), JsonbItem::Extension(other_data)) => {
                 let self_val = ExtensionValue::decode(self_data).ok()?;
                 let other_val = ExtensionValue::decode(other_data).ok()?;
                 self_val.partial_cmp(&other_val)
             }
-            (JsonbItem::Raw(self_raw), JsonbItem::Extension(other_val)) => {
+            (JsonbItem::Raw(self_raw), JsonbItem::Extension(other_data)) => {
                 let self_val = self_raw.as_extension_value();
                 let other_val = ExtensionValue::decode(other_data).ok()?;
                 if let Ok(Some(self_val)) = self_val {
@@ -197,7 +198,7 @@ impl PartialOrd for JsonbItem<'_> {
                     None
                 }
             }
-            (JsonbItem::Extension(self_val), JsonbItem::Raw(other_raw)) => {
+            (JsonbItem::Extension(self_data), JsonbItem::Raw(other_raw)) => {
                 let self_val = ExtensionValue::decode(self_data).ok()?;
                 let other_val = other_raw.as_extension_value();
                 if let Ok(Some(other_val)) = other_val {

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,6 +85,7 @@ pub enum Error {
     InvalidJsonbHeader,
     InvalidJsonbJEntry,
     InvalidJsonbNumber,
+    InvalidJsonbExtension,
 
     InvalidJsonPath,
     InvalidJsonPathPredicate,
@@ -123,13 +124,6 @@ impl Display for Error {
 
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        // match self {
-        //    Error::JsonError(e) => Some(e),
-        //    Error::Json5Error(e) => Some(e),
-        //    Error::Io(e) => Some(e),
-        //    Error::Utf8(e) => Some(e),
-        //    _ => None,
-        //}
         None
     }
 }

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -1,0 +1,205 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use jiff::civil::date;
+use jiff::fmt::strtime;
+use jiff::tz::Offset;
+use jiff::SignedDuration;
+
+const MICROS_PER_SEC: i64 = 1_000_000;
+const MICROS_PER_MINUTE: i64 = 60 * MICROS_PER_SEC;
+const MICROS_PER_HOUR: i64 = 60 * MICROS_PER_MINUTE;
+const MONTHS_PER_YEAR: i32 = 12;
+
+const TIMESTAMP_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.6f";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExtensionValue<'a> {
+    Binary(&'a [u8]),
+    Date(Date),
+    Timestamp(Timestamp),
+    TimestampTz(TimestampTz),
+    Interval(Interval),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Date {
+    pub value: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Timestamp {
+    pub value: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimestampTz {
+    pub offset: i8,
+    pub value: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Interval {
+    pub months: i32,
+    pub days: i32,
+    pub micros: i64,
+}
+
+impl Display for Date {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        let dur = SignedDuration::from_hours(self.value as i64 * 24);
+        let date = date(1970, 1, 1).checked_add(dur).unwrap();
+        write!(f, "{}", date)
+    }
+}
+
+impl Display for Timestamp {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        let micros = self.value;
+        let (mut secs, mut nanos) = (micros / MICROS_PER_SEC, (micros % MICROS_PER_SEC) * 1_000);
+        if nanos < 0 {
+            secs -= 1;
+            nanos += 1_000_000_000;
+        }
+
+        if secs > 253402207200 {
+            secs = 253402207200;
+            nanos = 0;
+        } else if secs < -377705023201 {
+            secs = -377705023201;
+            nanos = 0;
+        }
+        let ts = jiff::Timestamp::new(secs, nanos as i32).unwrap();
+
+        write!(f, "{}", strtime::format(TIMESTAMP_FORMAT, ts).unwrap())
+    }
+}
+
+impl Display for TimestampTz {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        let micros = self.value;
+        let (mut secs, mut nanos) = (micros / MICROS_PER_SEC, (micros % MICROS_PER_SEC) * 1_000);
+        if nanos < 0 {
+            secs -= 1;
+            nanos += 1_000_000_000;
+        }
+
+        if secs > 253402207200 {
+            secs = 253402207200;
+            nanos = 0;
+        } else if secs < -377705023201 {
+            secs = -377705023201;
+            nanos = 0;
+        }
+        let ts = jiff::Timestamp::new(secs, nanos as i32).unwrap();
+        let tz = Offset::constant(self.offset).to_time_zone();
+        let zoned = ts.to_zoned(tz);
+
+        write!(f, "{}", strtime::format(TIMESTAMP_FORMAT, &zoned).unwrap())
+    }
+}
+
+impl Display for Interval {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        let mut date_parts = vec![];
+        let years = self.months / MONTHS_PER_YEAR;
+        let months = self.months % MONTHS_PER_YEAR;
+        match years.cmp(&1) {
+            Ordering::Equal => {
+                date_parts.push((years, "year"));
+            }
+            Ordering::Greater => {
+                date_parts.push((years, "years"));
+            }
+            _ => {}
+        }
+        match months.cmp(&1) {
+            Ordering::Equal => {
+                date_parts.push((months, "month"));
+            }
+            Ordering::Greater => {
+                date_parts.push((months, "months"));
+            }
+            _ => {}
+        }
+        match self.days.cmp(&1) {
+            Ordering::Equal => {
+                date_parts.push((self.days, "day"));
+            }
+            Ordering::Greater => {
+                date_parts.push((self.days, "days"));
+            }
+            _ => {}
+        }
+        if !date_parts.is_empty() {
+            for (i, (val, name)) in date_parts.into_iter().enumerate() {
+                if i > 0 {
+                    write!(f, " ")?;
+                }
+                write!(f, "{} {}", val, name)?;
+            }
+            if self.micros != 0 {
+                write!(f, " ")?;
+            }
+        }
+
+        if self.micros != 0 {
+            let mut micros = self.micros;
+            if micros < 0 {
+                write!(f, "-")?;
+                micros = -micros;
+            }
+            let hour = micros / MICROS_PER_HOUR;
+            micros -= hour * MICROS_PER_HOUR;
+            let min = micros / MICROS_PER_MINUTE;
+            micros -= min * MICROS_PER_MINUTE;
+            let sec = micros / MICROS_PER_SEC;
+            micros -= sec * MICROS_PER_SEC;
+
+            if hour < 100 {
+                write!(f, "{:02}:{:02}:{:02}", hour, min, sec)?;
+            } else {
+                write!(f, "{}:{:02}:{:02}", hour, min, sec)?;
+            }
+            if micros != 0 {
+                write!(f, ".{:06}", micros)?;
+            }
+        } else if self.months == 0 && self.days == 0 {
+            write!(f, "00:00:00")?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for ExtensionValue<'_> {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            ExtensionValue::Binary(v) => {
+                for c in *v {
+                    write!(f, "{c:02X}")?;
+                }
+                Ok(())
+            }
+            ExtensionValue::Date(v) => write!(f, "{}", v),
+            ExtensionValue::Timestamp(v) => write!(f, "{}", v),
+            ExtensionValue::TimestampTz(v) => write!(f, "{}", v),
+            ExtensionValue::Interval(v) => write!(f, "{}", v),
+        }
+    }
+}

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -216,18 +216,18 @@ impl PartialEq for ExtensionValue<'_> {
 impl PartialOrd for ExtensionValue<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         let self_level = match self {
-            ExtensionValue::Binary(_) => 4,
-            ExtensionValue::Date(_) => 3,
+            ExtensionValue::Binary(_) => 0,
+            ExtensionValue::Date(_) => 1,
             ExtensionValue::Timestamp(_) => 2,
-            ExtensionValue::TimestampTz(_) => 1,
-            ExtensionValue::Interval(_) => 0,
+            ExtensionValue::TimestampTz(_) => 3,
+            ExtensionValue::Interval(_) => 4,
         };
         let other_level = match other {
-            ExtensionValue::Binary(_) => 4,
-            ExtensionValue::Date(_) => 3,
+            ExtensionValue::Binary(_) => 0,
+            ExtensionValue::Date(_) => 1,
             ExtensionValue::Timestamp(_) => 2,
-            ExtensionValue::TimestampTz(_) => 1,
-            ExtensionValue::Interval(_) => 0,
+            ExtensionValue::TimestampTz(_) => 3,
+            ExtensionValue::Interval(_) => 4,
         };
         let res = self_level.cmp(&other_level);
         if matches!(res, Ordering::Greater | Ordering::Less) {

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -38,23 +38,23 @@ pub enum ExtensionValue<'a> {
     Interval(Interval),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Date {
     pub value: i32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Timestamp {
     pub value: i64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct TimestampTz {
     pub offset: i8,
     pub value: i64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Interval {
     pub months: i32,
     pub days: i32,
@@ -229,10 +229,9 @@ impl PartialOrd for ExtensionValue<'_> {
             ExtensionValue::TimestampTz(_) => 1,
             ExtensionValue::Interval(_) => 0,
         };
-        if self_level > other_level {
-            return Some(Ordering::Greater);
-        } else if self_level < other_level {
-            return Some(Ordering::Less);
+        let res = self_level.cmp(&other_level);
+        if matches!(res, Ordering::Greater | Ordering::Less) {
+            return Some(res);
         }
 
         match (self, other) {
@@ -251,6 +250,7 @@ impl PartialOrd for ExtensionValue<'_> {
             (ExtensionValue::Interval(self_data), ExtensionValue::Interval(other_data)) => {
                 Some(self_data.cmp(other_data))
             }
+            (_, _) => None,
         }
     }
 }

--- a/src/from.rs
+++ b/src/from.rs
@@ -197,8 +197,37 @@ impl<'a> From<Value<'a>> for JsonValue {
                 Number::Int64(v) => JsonValue::Number(v.into()),
                 Number::UInt64(v) => JsonValue::Number(v.into()),
                 Number::Float64(v) => JsonValue::Number(JsonNumber::from_f64(v).unwrap()),
+                Number::Decimal128(v) => {
+                    JsonValue::Number(JsonNumber::from_f64(v.to_float64()).unwrap())
+                }
+                Number::Decimal256(v) => {
+                    JsonValue::Number(JsonNumber::from_f64(v.to_float64()).unwrap())
+                }
             },
             Value::String(v) => JsonValue::String(v.to_string()),
+            Value::Binary(v) => {
+                let mut s = String::new();
+                for c in v {
+                    s.push_str(&format!("{c:02X}"));
+                }
+                JsonValue::String(s)
+            }
+            Value::Date(v) => {
+                let s = format!("{}", v);
+                JsonValue::String(s)
+            }
+            Value::Timestamp(v) => {
+                let s = format!("{}", v);
+                JsonValue::String(s)
+            }
+            Value::TimestampTz(v) => {
+                let s = format!("{}", v);
+                JsonValue::String(s)
+            }
+            Value::Interval(v) => {
+                let s = format!("{}", v);
+                JsonValue::String(s)
+            }
             Value::Array(arr) => {
                 let mut vals: Vec<JsonValue> = Vec::with_capacity(arr.len());
                 for val in arr {

--- a/src/functions/scalar.rs
+++ b/src/functions/scalar.rs
@@ -1496,7 +1496,7 @@ impl RawJsonb<'_> {
     /// let binary_value = Value::Binary(&[1,2,3]);
     /// let buf = binary_value.to_vec();
     /// let raw_jsonb = RawJsonb::new(&buf);
-    /// assert_eq!(raw_jsonb.as_extension_value().unwrap(), Some(ExtensionValue::Binary(&[1,2,3]));
+    /// assert_eq!(raw_jsonb.as_extension_value().unwrap(), Some(ExtensionValue::Binary(&[1,2,3])));
     /// ```
     pub fn as_extension_value(&self) -> Result<Option<ExtensionValue>> {
         let jsonb_item = JsonbItem::from_raw_jsonb(*self)?;

--- a/src/functions/scalar.rs
+++ b/src/functions/scalar.rs
@@ -19,7 +19,12 @@ use std::borrow::Cow;
 use crate::core::JsonbItem;
 use crate::core::JsonbItemType;
 use crate::error::*;
+use crate::extension::Date;
+use crate::extension::Interval;
+use crate::extension::Timestamp;
+use crate::extension::TimestampTz;
 use crate::number::Number;
+use crate::ExtensionValue;
 use crate::RawJsonb;
 
 impl RawJsonb<'_> {
@@ -1434,5 +1439,448 @@ impl RawJsonb<'_> {
     pub fn is_object(&self) -> Result<bool> {
         let jsonb_item_type = self.jsonb_item_type()?;
         Ok(matches!(jsonb_item_type, JsonbItemType::Object(_)))
+    }
+
+    /// Checks if the JSONB value is a binary value.
+    ///
+    /// This function checks if the JSONB value represents a binary value.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The JSONB value.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(true)` - If the value is a binary value.
+    /// * `Ok(false)` - If the value is not a binary value.
+    /// * `Err(Error)` - If the JSONB data is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use jsonb::RawJsonb;
+    /// use jsonb::Value;
+    ///
+    /// // Binary value
+    /// let binary_value = Value::Binary(&[1,2,3]);
+    /// let buf = binary_value.to_vec();
+    /// let raw_jsonb = RawJsonb::new(&buf);
+    /// assert!(raw_jsonb.is_binary().unwrap());
+    /// ```
+    pub fn is_binary(&self) -> Result<bool> {
+        let jsonb_item_type = self.jsonb_item_type()?;
+        match jsonb_item_type {
+            JsonbItemType::Extension => {
+                let jsonb_item = JsonbItem::from_raw_jsonb(*self)?;
+                match jsonb_item {
+                    JsonbItem::Extension(data) => {
+                        let val = ExtensionValue::decode(data)?;
+                        match val {
+                            ExtensionValue::Binary(_v) => Ok(true),
+                            _ => Ok(false),
+                        }
+                    }
+                    _ => Err(Error::InvalidJsonb),
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
+    /// Extracts a binary value from a JSONB value.
+    ///
+    /// This function attempts to extract a binary value from the JSONB value.
+    /// If the JSONB value is a binary value, it returns the binary; otherwise, it returns `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The JSONB value.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(Vec<u8>))` - If the value is a binary value, the extracted binary value.
+    /// * `Ok(None)` - If the value is not a binary value.
+    /// * `Err(Error)` - If the JSONB data is invalid or if the binary value cannot be decoded.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use jsonb::RawJsonb;
+    /// use jsonb::Value;
+    ///
+    /// // Binary value
+    /// let binary_value = Value::Binary(&[1,2,3]);
+    /// let buf = binary_value.to_vec();
+    /// let raw_jsonb = RawJsonb::new(&buf);
+    /// assert_eq!(raw_jsonb.as_binary().unwrap(), Some(vec![1,2,3]));
+    /// ```
+    pub fn as_binary(&self) -> Result<Option<Vec<u8>>> {
+        let jsonb_item = JsonbItem::from_raw_jsonb(*self)?;
+        match jsonb_item {
+            JsonbItem::Extension(data) => {
+                let val = ExtensionValue::decode(data)?;
+                match val {
+                    ExtensionValue::Binary(v) => Ok(Some(v.to_vec())),
+                    _ => Ok(None),
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Checks if the JSONB value is a date value.
+    ///
+    /// This function checks if the JSONB value represents a date value.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The JSONB value.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(true)` - If the value is a date value.
+    /// * `Ok(false)` - If the value is not a date value.
+    /// * `Err(Error)` - If the JSONB data is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use jsonb::Date;
+    /// use jsonb::RawJsonb;
+    /// use jsonb::Value;
+    ///
+    /// // Date value
+    /// let date_value = Value::Date(Date { value: 20372 });
+    /// let buf = date_value.to_vec();
+    /// let raw_jsonb = RawJsonb::new(&buf);
+    /// assert!(raw_jsonb.is_date().unwrap());
+    /// ```
+    pub fn is_date(&self) -> Result<bool> {
+        let jsonb_item_type = self.jsonb_item_type()?;
+        match jsonb_item_type {
+            JsonbItemType::Extension => {
+                let jsonb_item = JsonbItem::from_raw_jsonb(*self)?;
+                match jsonb_item {
+                    JsonbItem::Extension(data) => {
+                        let val = ExtensionValue::decode(data)?;
+                        match val {
+                            ExtensionValue::Date(_v) => Ok(true),
+                            _ => Ok(false),
+                        }
+                    }
+                    _ => Err(Error::InvalidJsonb),
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
+    /// Extracts a date value from a JSONB value.
+    ///
+    /// This function attempts to extract a date value from the JSONB value.
+    /// If the JSONB value is a date value, it returns the date; otherwise, it returns `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The JSONB value.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(Date))` - If the value is a date value, the extracted date value.
+    /// * `Ok(None)` - If the value is not a date value.
+    /// * `Err(Error)` - If the JSONB data is invalid or if the date value cannot be decoded.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use jsonb::Date;
+    /// use jsonb::RawJsonb;
+    /// use jsonb::Value;
+    ///
+    /// // Date value
+    /// let date_value = Value::Date(Date { value: 20372 });
+    /// let buf = date_value.to_vec();
+    /// let raw_jsonb = RawJsonb::new(&buf);
+    /// assert_eq!(raw_jsonb.as_date().unwrap(), Some(Date { value: 20372 }));
+    /// ```
+    pub fn as_date(&self) -> Result<Option<Date>> {
+        let jsonb_item = JsonbItem::from_raw_jsonb(*self)?;
+        match jsonb_item {
+            JsonbItem::Extension(data) => {
+                let val = ExtensionValue::decode(data)?;
+                match val {
+                    ExtensionValue::Date(v) => Ok(Some(v)),
+                    _ => Ok(None),
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Checks if the JSONB value is a timestamp value.
+    ///
+    /// This function checks if the JSONB value represents a timestamp value.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The JSONB value.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(true)` - If the value is a timestamp value.
+    /// * `Ok(false)` - If the value is not a timestamp value.
+    /// * `Err(Error)` - If the JSONB data is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use jsonb::Timestamp;
+    /// use jsonb::RawJsonb;
+    /// use jsonb::Value;
+    ///
+    /// // Timestamp value
+    /// let timestamp_value = Value::Timestamp(Timestamp { value: 1760140800000000 });
+    /// let buf = timestamp_value.to_vec();
+    /// let raw_jsonb = RawJsonb::new(&buf);
+    /// assert!(raw_jsonb.is_timestamp().unwrap());
+    /// ```
+    pub fn is_timestamp(&self) -> Result<bool> {
+        let jsonb_item_type = self.jsonb_item_type()?;
+        match jsonb_item_type {
+            JsonbItemType::Extension => {
+                let jsonb_item = JsonbItem::from_raw_jsonb(*self)?;
+                match jsonb_item {
+                    JsonbItem::Extension(data) => {
+                        let val = ExtensionValue::decode(data)?;
+                        match val {
+                            ExtensionValue::Timestamp(_v) => Ok(true),
+                            _ => Ok(false),
+                        }
+                    }
+                    _ => Err(Error::InvalidJsonb),
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
+    /// Extracts a timestamp value from a JSONB value.
+    ///
+    /// This function attempts to extract a timestamp value from the JSONB value.
+    /// If the JSONB value is a timestamp value, it returns the timestamp; otherwise, it returns `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The JSONB value.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(Timestamp))` - If the value is a timestamp value, the extracted timestamp value.
+    /// * `Ok(None)` - If the value is not a timestamp value.
+    /// * `Err(Error)` - If the JSONB data is invalid or if the timestamp value cannot be decoded.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use jsonb::Timestamp;
+    /// use jsonb::RawJsonb;
+    /// use jsonb::Value;
+    ///
+    /// // Timestamp value
+    /// let timestamp_value = Value::Timestamp(Timestamp { value: 1760140800000000 });
+    /// let buf = timestamp_value.to_vec();
+    /// let raw_jsonb = RawJsonb::new(&buf);
+    /// assert_eq!(raw_jsonb.as_timestamp().unwrap(), Some(Timestamp { value: 1760140800000000 }));
+    /// ```
+    pub fn as_timestamp(&self) -> Result<Option<Timestamp>> {
+        let jsonb_item = JsonbItem::from_raw_jsonb(*self)?;
+        match jsonb_item {
+            JsonbItem::Extension(data) => {
+                let val = ExtensionValue::decode(data)?;
+                match val {
+                    ExtensionValue::Timestamp(v) => Ok(Some(v)),
+                    _ => Ok(None),
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Checks if the JSONB value is a timestamp tz value.
+    ///
+    /// This function checks if the JSONB value represents a timestamp tz value.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The JSONB value.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(true)` - If the value is a timestamp tz value.
+    /// * `Ok(false)` - If the value is not a timestamp tz value.
+    /// * `Err(Error)` - If the JSONB data is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use jsonb::TimestampTz;
+    /// use jsonb::RawJsonb;
+    /// use jsonb::Value;
+    ///
+    /// // TimestampTz value
+    /// let timestamp_tz_value = Value::TimestampTz(TimestampTz { offset: 8, value: 1760140800000000 });
+    /// let buf = timestamp_tz_value.to_vec();
+    /// let raw_jsonb = RawJsonb::new(&buf);
+    /// assert!(raw_jsonb.is_timestamp_tz().unwrap());
+    /// ```
+    pub fn is_timestamp_tz(&self) -> Result<bool> {
+        let jsonb_item_type = self.jsonb_item_type()?;
+        match jsonb_item_type {
+            JsonbItemType::Extension => {
+                let jsonb_item = JsonbItem::from_raw_jsonb(*self)?;
+                match jsonb_item {
+                    JsonbItem::Extension(data) => {
+                        let val = ExtensionValue::decode(data)?;
+                        match val {
+                            ExtensionValue::TimestampTz(_v) => Ok(true),
+                            _ => Ok(false),
+                        }
+                    }
+                    _ => Err(Error::InvalidJsonb),
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
+    /// Extracts a timestamp tz value from a JSONB value.
+    ///
+    /// This function attempts to extract a timestamp tz value from the JSONB value.
+    /// If the JSONB value is a timestamp tz value, it returns the timestamp tz; otherwise, it returns `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The JSONB value.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(TimestampTz))` - If the value is a timestamp tz value, the extracted timestamp value.
+    /// * `Ok(None)` - If the value is not a timestamp tz value.
+    /// * `Err(Error)` - If the JSONB data is invalid or if the timestamp tz value cannot be decoded.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use jsonb::TimestampTz;
+    /// use jsonb::RawJsonb;
+    /// use jsonb::Value;
+    ///
+    /// // TimestampTz value
+    /// let timestamp_tz_value = Value::TimestampTz(TimestampTz { offset: 8, value: 1760140800000000 });
+    /// let buf = timestamp_tz_value.to_vec();
+    /// let raw_jsonb = RawJsonb::new(&buf);
+    /// assert_eq!(raw_jsonb.as_timestamp_tz().unwrap(), Some(TimestampTz { offset: 8, value: 1760140800000000 }));
+    /// ```
+    pub fn as_timestamp_tz(&self) -> Result<Option<TimestampTz>> {
+        let jsonb_item = JsonbItem::from_raw_jsonb(*self)?;
+        match jsonb_item {
+            JsonbItem::Extension(data) => {
+                let val = ExtensionValue::decode(data)?;
+                match val {
+                    ExtensionValue::TimestampTz(v) => Ok(Some(v)),
+                    _ => Ok(None),
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Checks if the JSONB value is a interval value.
+    ///
+    /// This function checks if the JSONB value represents a interval value.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The JSONB value.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(true)` - If the value is a interval value.
+    /// * `Ok(false)` - If the value is not a interval value.
+    /// * `Err(Error)` - If the JSONB data is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use jsonb::Interval;
+    /// use jsonb::RawJsonb;
+    /// use jsonb::Value;
+    ///
+    /// // Interval value
+    /// let interval_value = Value::Interval(Interval { months: 10, days: 20, micros: 300000000 });
+    /// let buf = interval_value.to_vec();
+    /// let raw_jsonb = RawJsonb::new(&buf);
+    /// assert!(raw_jsonb.is_interval().unwrap());
+    /// ```
+    pub fn is_interval(&self) -> Result<bool> {
+        let jsonb_item_type = self.jsonb_item_type()?;
+        match jsonb_item_type {
+            JsonbItemType::Extension => {
+                let jsonb_item = JsonbItem::from_raw_jsonb(*self)?;
+                match jsonb_item {
+                    JsonbItem::Extension(data) => {
+                        let val = ExtensionValue::decode(data)?;
+                        match val {
+                            ExtensionValue::Interval(_v) => Ok(true),
+                            _ => Ok(false),
+                        }
+                    }
+                    _ => Err(Error::InvalidJsonb),
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
+    /// Extracts a interval value from a JSONB value.
+    ///
+    /// This function attempts to extract a interval value from the JSONB value.
+    /// If the JSONB value is a interval value, it returns the interval; otherwise, it returns `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The JSONB value.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(Interval))` - If the value is a interval value, the extracted timestamp value.
+    /// * `Ok(None)` - If the value is not a interval value.
+    /// * `Err(Error)` - If the JSONB data is invalid or if the interval value cannot be decoded.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use jsonb::Interval;
+    /// use jsonb::RawJsonb;
+    /// use jsonb::Value;
+    ///
+    /// // Interval value
+    /// let interval_value = Value::Interval(Interval { months: 10, days: 20, micros: 300000000 });
+    /// let buf = interval_value.to_vec();
+    /// let raw_jsonb = RawJsonb::new(&buf);
+    /// assert_eq!(raw_jsonb.as_interval().unwrap(), Some(Interval { months: 10, days: 20, micros: 300000000 }));
+    /// ```
+    pub fn as_interval(&self) -> Result<Option<Interval>> {
+        let jsonb_item = JsonbItem::from_raw_jsonb(*self)?;
+        match jsonb_item {
+            JsonbItem::Extension(data) => {
+                let val = ExtensionValue::decode(data)?;
+                match val {
+                    ExtensionValue::Interval(v) => Ok(Some(v)),
+                    _ => Ok(None),
+                }
+            }
+            _ => Ok(None),
+        }
     }
 }

--- a/src/functions/scalar.rs
+++ b/src/functions/scalar.rs
@@ -1489,6 +1489,7 @@ impl RawJsonb<'_> {
     /// # Examples
     ///
     /// ```rust
+    /// use jsonb::ExtensionValue;
     /// use jsonb::RawJsonb;
     /// use jsonb::Value;
     ///

--- a/src/functions/scalar.rs
+++ b/src/functions/scalar.rs
@@ -1441,6 +1441,74 @@ impl RawJsonb<'_> {
         Ok(matches!(jsonb_item_type, JsonbItemType::Object(_)))
     }
 
+    /// Checks if the JSONB value is a extension(binary, date, timestamp, timestamp_tz, interval) value.
+    ///
+    /// This function checks if the JSONB value represents a extension value.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The JSONB value.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(true)` - If the value is a extension value.
+    /// * `Ok(false)` - If the value is not a extension value.
+    /// * `Err(Error)` - If the JSONB data is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use jsonb::RawJsonb;
+    /// use jsonb::Value;
+    ///
+    /// // Binary value
+    /// let binary_value = Value::Binary(&[1,2,3]);
+    /// let buf = binary_value.to_vec();
+    /// let raw_jsonb = RawJsonb::new(&buf);
+    /// assert!(raw_jsonb.is_extension_value().unwrap());
+    /// ```
+    pub fn is_extension_value(&self) -> Result<bool> {
+        let jsonb_item_type = self.jsonb_item_type()?;
+        Ok(matches!(jsonb_item_type, JsonbItemType::Extension))
+    }
+
+    /// Extracts a extension value from a JSONB value.
+    ///
+    /// This function attempts to extract a extension value from the JSONB value.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The JSONB value.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(ExtensionValue))` - If the value is a extension value, the extracted extension value.
+    /// * `Ok(None)` - If the value is not a extension value.
+    /// * `Err(Error)` - If the JSONB data is invalid or if the extension value cannot be decoded.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use jsonb::RawJsonb;
+    /// use jsonb::Value;
+    ///
+    /// // Binary value
+    /// let binary_value = Value::Binary(&[1,2,3]);
+    /// let buf = binary_value.to_vec();
+    /// let raw_jsonb = RawJsonb::new(&buf);
+    /// assert_eq!(raw_jsonb.as_extension_value().unwrap(), Some(ExtensionValue::Binary(&[1,2,3]));
+    /// ```
+    pub fn as_extension_value(&self) -> Result<Option<ExtensionValue>> {
+        let jsonb_item = JsonbItem::from_raw_jsonb(*self)?;
+        match jsonb_item {
+            JsonbItem::Extension(data) => {
+                let val = ExtensionValue::decode(data)?;
+                Ok(Some(val))
+            }
+            _ => Ok(None),
+        }
+    }
+
     /// Checks if the JSONB value is a binary value.
     ///
     /// This function checks if the JSONB value represents a binary value.
@@ -1490,7 +1558,6 @@ impl RawJsonb<'_> {
     /// Extracts a binary value from a JSONB value.
     ///
     /// This function attempts to extract a binary value from the JSONB value.
-    /// If the JSONB value is a binary value, it returns the binary; otherwise, it returns `None`.
     ///
     /// # Arguments
     ///
@@ -1578,7 +1645,6 @@ impl RawJsonb<'_> {
     /// Extracts a date value from a JSONB value.
     ///
     /// This function attempts to extract a date value from the JSONB value.
-    /// If the JSONB value is a date value, it returns the date; otherwise, it returns `None`.
     ///
     /// # Arguments
     ///
@@ -1667,7 +1733,6 @@ impl RawJsonb<'_> {
     /// Extracts a timestamp value from a JSONB value.
     ///
     /// This function attempts to extract a timestamp value from the JSONB value.
-    /// If the JSONB value is a timestamp value, it returns the timestamp; otherwise, it returns `None`.
     ///
     /// # Arguments
     ///
@@ -1756,7 +1821,6 @@ impl RawJsonb<'_> {
     /// Extracts a timestamp tz value from a JSONB value.
     ///
     /// This function attempts to extract a timestamp tz value from the JSONB value.
-    /// If the JSONB value is a timestamp tz value, it returns the timestamp tz; otherwise, it returns `None`.
     ///
     /// # Arguments
     ///
@@ -1845,7 +1909,6 @@ impl RawJsonb<'_> {
     /// Extracts a interval value from a JSONB value.
     ///
     /// This function attempts to extract a interval value from the JSONB value.
-    /// If the JSONB value is a interval value, it returns the interval; otherwise, it returns `None`.
     ///
     /// # Arguments
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@
 mod constants;
 pub mod core;
 mod error;
+mod extension;
 mod from;
 mod functions;
 pub mod jsonpath;
@@ -78,8 +79,11 @@ mod util;
 mod value;
 
 pub use error::Error;
+pub use extension::*;
 #[allow(unused_imports)]
 pub use from::*;
+pub use number::Decimal128;
+pub use number::Decimal256;
 pub use number::Number;
 pub use owned::to_owned_jsonb;
 pub use owned::OwnedJsonb;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -217,7 +217,7 @@ impl PartialEq for RawJsonb<'_> {
 /// The ordering is defined as follows:
 ///
 /// 1. Null is considered greater than any other type.
-/// 2. Scalars are compared based on their type and value (String > Number > Boolean).
+/// 2. Scalars are compared based on their type and value (String > Number > Boolean > ExtensionValue).
 /// 3. Arrays are compared element by element.
 /// 4. Objects are compared based on their keys and values.
 /// 5. Arrays are greater than objects and scalars.
@@ -287,6 +287,14 @@ impl PartialOrd for RawJsonb<'_> {
             (JsonbItemType::Boolean, JsonbItemType::Boolean) => {
                 let self_val = self.as_bool();
                 let other_val = other.as_bool();
+                match (self_val, other_val) {
+                    (Ok(Some(self_val)), Ok(Some(other_val))) => self_val.partial_cmp(&other_val),
+                    (_, _) => None,
+                }
+            }
+            (JsonbItemType::Extension, JsonbItemType::Extension) => {
+                let self_val = self.as_extension_value();
+                let other_val = other.as_extension_value();
                 match (self_val, other_val) {
                     (Ok(Some(self_val)), Ok(Some(other_val))) => self_val.partial_cmp(&other_val),
                     (_, _) => None,

--- a/tests/it/encode.rs
+++ b/tests/it/encode.rs
@@ -14,7 +14,10 @@
 
 use std::borrow::Cow;
 
-use jsonb::{Number, Object, Value};
+use ethnum::I256;
+use jsonb::{
+    Date, Decimal128, Decimal256, Interval, Number, Object, Timestamp, TimestampTz, Value,
+};
 
 #[test]
 fn test_encode_null() {
@@ -132,11 +135,58 @@ fn test_encode_float64() {
 }
 
 #[test]
+fn test_encode_decimal() {
+    assert_eq!(
+        &Value::Number(Number::Decimal128(Decimal128 {
+            precision: 38,
+            scale: 2,
+            value: 1234
+        }))
+        .to_vec(),
+        b"\x20\0\0\0\x20\0\0\x13\x70\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x04\xD2\x26\x02"
+    );
+    assert_eq!(
+        &Value::Number(Number::Decimal128(Decimal128 {
+            precision: 38,
+            scale: 10,
+            value: 10000000000485
+        }))
+        .to_vec(),
+        b"\x20\0\0\0\x20\0\0\x13\x70\0\0\0\0\0\0\0\0\0\0\x09\x18\x4E\x72\xA1\xE5\x26\x0A"
+    );
+
+    assert_eq!(
+        &Value::Number(Number::Decimal256(Decimal256 { precision: 76, scale: 2, value: I256::new(1234) })).to_vec(),
+        b"\x20\0\0\0\x20\0\0\x23\x70\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x04\xD2\x4C\x02"
+    );
+    assert_eq!(
+        &Value::Number(Number::Decimal256(Decimal256 { precision: 76, scale: 10, value: I256::new(10000000000485) })).to_vec(),
+        b"\x20\0\0\0\x20\0\0\x23\x70\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x09\x18\x4E\x72\xA1\xE5\x4C\x0A"
+    );
+}
+
+#[test]
 fn test_encode_array() {
-    let raw = b"\x80\0\0\x02\x30\0\0\0\x40\0\0\0";
     assert_eq!(
         &Value::Array(vec![Value::Bool(false), Value::Bool(true)]).to_vec(),
-        raw
+        b"\x80\0\0\x02\x30\0\0\0\x40\0\0\0",
+    );
+
+    let buf = Value::Array(vec![Value::Bool(false), Value::Bool(true)]).to_vec();
+    let raw_jsonb = jsonb::RawJsonb::new(&buf);
+    println!("{}", raw_jsonb.to_string());
+
+    assert_eq!(
+        &Value::Array(vec![
+            Value::Bool(false),
+            Value::Binary(&[100, 101, 102, 103]),
+            Value::Date(Date {value: 20381 }),
+            Value::Timestamp(Timestamp { value: 1540230120000000 }),
+            Value::TimestampTz(TimestampTz { offset: 8, value: 1670389100000000 }),
+            Value::Interval(Interval { months: 2, days: 10, micros: 500000000 }),
+            Value::Number(Number::Decimal256(Decimal256 { precision: 76, scale: 2, value: I256::new(1234) })),
+        ]).to_vec(),
+        b"\x80\0\0\x07\x30\0\0\0\x60\0\0\x05\x60\0\0\x05\x60\0\0\x09\x60\0\0\x0A\x60\0\0\x11\x20\0\0\x23\0\x64\x65\x66\x67\x10\0\0\x4F\x9D\x20\0\x05\x78\xD4\xC5\x2C\xCA\0\x30\0\x05\xEF\x35\xC4\xF1\x33\0\x08\x40\0\0\0\x02\0\0\0\x0A\0\0\0\0\x1D\xCD\x65\0\x70\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x04\xD2\x4C\x02",
     );
 }
 
@@ -147,5 +197,80 @@ fn test_encode_object() {
     assert_eq!(
         &Value::Object(obj1).to_vec(),
         b"\x40\0\0\x01\x10\0\0\x03\x10\0\0\x03\x61\x73\x64\x61\x64\x66"
+    );
+
+    let mut obj2 = Object::new();
+    obj2.insert("k1".to_string(), Value::String(Cow::from("v1")));
+    obj2.insert("k2".to_string(), Value::Binary(&[200, 201, 202, 203]));
+    obj2.insert("k3".to_string(), Value::Date(Date { value: 20381 }));
+    obj2.insert(
+        "k4".to_string(),
+        Value::Timestamp(Timestamp {
+            value: 1540230120000000,
+        }),
+    );
+    obj2.insert(
+        "k5".to_string(),
+        Value::TimestampTz(TimestampTz {
+            offset: 8,
+            value: 1670389100000000,
+        }),
+    );
+    obj2.insert(
+        "k6".to_string(),
+        Value::Interval(Interval {
+            months: 2,
+            days: 10,
+            micros: 500000000,
+        }),
+    );
+    obj2.insert(
+        "k7".to_string(),
+        Value::Number(Number::Decimal256(Decimal256 {
+            precision: 76,
+            scale: 2,
+            value: I256::new(1234),
+        })),
+    );
+
+    assert_eq!(
+        &Value::Object(obj2).to_vec(),
+        b"\x40\0\0\x07\x10\0\0\x02\x10\0\0\x02\x10\0\0\x02\x10\0\0\x02\x10\0\0\x02\x10\0\0\x02\x10\0\0\x02\x10\0\0\x02\x60\0\0\x05\x60\0\0\x05\x60\0\0\x09\x60\0\0\x0A\x60\0\0\x11\x20\0\0\x23\x6B\x31\x6B\x32\x6B\x33\x6B\x34\x6B\x35\x6B\x36\x6B\x37\x76\x31\0\xC8\xC9\xCA\xCB\x10\0\0\x4F\x9D\x20\0\x05\x78\xD4\xC5\x2C\xCA\0\x30\0\x05\xEF\x35\xC4\xF1\x33\0\x08\x40\0\0\0\x02\0\0\0\x0A\0\0\0\0\x1D\xCD\x65\0\x70\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x04\xD2\x4C\x02"
+    );
+}
+
+#[test]
+fn test_encode_extension() {
+    assert_eq!(
+        Value::Binary(&[1, 2, 3]).to_vec(),
+        b"\x20\0\0\0\x60\0\0\x04\0\x01\x02\x03"
+    );
+    assert_eq!(
+        Value::Date(Date { value: 20372 }).to_vec(),
+        b"\x20\0\0\0\x60\0\0\x05\x10\0\0\x4f\x94"
+    );
+    assert_eq!(
+        Value::Timestamp(Timestamp {
+            value: 1760140800000000
+        })
+        .to_vec(),
+        b"\x20\0\0\0\x60\0\0\x09\x20\0\x06\x40\xd6\xb7\x23\x80\0"
+    );
+    assert_eq!(
+        Value::TimestampTz(TimestampTz {
+            offset: 8,
+            value: 1760140800000000
+        })
+        .to_vec(),
+        b"\x20\0\0\0\x60\0\0\x0a\x30\0\x06\x40\xd6\xb7\x23\x80\0\x08"
+    );
+    assert_eq!(
+        Value::Interval(Interval {
+            months: 10,
+            days: 20,
+            micros: 300000000
+        })
+        .to_vec(),
+        b"\x20\0\0\0\x60\0\0\x11\x40\0\0\0\x0A\0\0\0\x14\0\0\0\0\x11\xE1\xA3\0"
     );
 }


### PR DESCRIPTION
support extension types
- binary
- decimal
- date
- timestamp
- timestamp_tz
- interval

jsonb consists of three parts: `header`, `jentry`, and `payload`. Both the `header` and `jentry` are of fixed length of 32 bits, while the `payload` is not fixed in length and varies according to the specific data type. The overall structure is shown in the following figure:
```
┌────────┬─────────┬─────────┬─────┬─────────┬──────────┬──────────┬─────┬──────────┐
│ header │ jentry1 │ jentry2 │ ... │ jentryN │ payload1 │ payload2 │ ... │ payloadN │
└────────┴─────────┴─────────┴─────┴─────────┴──────────┴──────────┴─────┴──────────┘
```
The `header` contains the type of data and the number of internal elements
```
┌─────────────┬──────────────────────┐
│ type(3 bit) │ item numbers(29 bit) │
└─────────────┴──────────────────────┘
```
The `jentry` contains the type of item data and the length of the payload, The flag is used to identify whether the third field is length or offset (not in use yet).
```
┌─────────────┬─────────────┬────────────────┐
│ flag(1 bit) │ type(3 bit) │ length(28 bit) │
└─────────────┴─────────────┴────────────────┘
```
There are the following 6 types of type. A total of 8 types can be represented by 3 bits, which can be used to support extended types
- 000 NULL
- 001 String
- 010 Number
- 011 False 
- 100 True
- 101 Container

Add a new Extension type

- 110 Extension

It contains five subtypes: `Binary`, `Date`, `Timestamp`, `TimestampTz`, `Interval`, and payload. The first byte stores the subtypes, and the subsequent fields store different data according to the types

- 0x00 Binary
- 0x10 Date
- 0x20 Timestamp
- 0x30 TimestampTz
- 0x40 Interval

```
Binary
┌─────────────────────┬─────────────┐
│ subtype(8 bit) 0x00 │ binary data │
└─────────────────────┴─────────────┘
Date
┌─────────────────────┬──────────────┐
│ subtype(8 bit) 0x10 │ date(32 bit) │
└─────────────────────┴──────────────┘
Timestamp
┌─────────────────────┬───────────────────┐
│ subtype(8 bit) 0x20 │ timestamp(64 bit) │
└─────────────────────┴───────────────────┘
TimestampTz
┌─────────────────────┬───────────┬───────────────────┐
│ subtype(8 bit) 0x30 │ tz(8 bit) │ timestamp(64 bit) │
└─────────────────────┴───────────┴───────────────────┘
Interval
┌─────────────────────┬────────────────┬──────────────┬──────────────────────┐
│ subtype(8 bit) 0x40 │ months(32 bit) │ days(32 bit) │ microseconds(64 bit) │
└─────────────────────┴────────────────┴──────────────┴──────────────────────┘
```

Decimal needs to perform numerical calculations and serves as a subtype of the Number type

```
Decimal128
┌─────────────────────┬──────────────────┬──────────────┬────────────────┐
│ subtype(8 bit) 0x70 │ precision(8 bit) │ scale(8 bit) │ value(128 bit) │
└─────────────────────┴──────────────────┴──────────────┴────────────────┘
Decimal256
┌─────────────────────┬──────────────────┬──────────────┬────────────────┐
│ subtype(8 bit) 0x70 │ precision(8 bit) │ scale(8 bit) │ value(256 bit) │
└─────────────────────┴──────────────────┴──────────────┴────────────────┘
```


